### PR TITLE
Add conventional bin executable script.

### DIFF
--- a/bin/yui-configger
+++ b/bin/yui-configger
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("../lib/configger.js").run();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version" : "0.0.1",
     "description" : "Extract meta-data from a folder of YUI modules & generate a Loader config",
     "preferGlobal" : true,
+    "bin": "./bin/yui-configger",
     "bugs" : "https://github.com/tivac/yui-configger/issues",
     "main" : "./lib/configger.js",
     "repository": {


### PR DESCRIPTION
When npm installs this shell script on Windows, a .cmd helper is automagically created to interface with it. (the shebang is ignored)

The index.js pattern is for programmatic use (via `require("yui-configger")`) in other node scripts. This is more idiomatic npm. :)

Instead of `node index.js -r tests\data`:

```
# in yui-configger repo root
npm -g install .
# anywhere afterward
yui-configger -r path/to/root
```
