### PR TITLE
Add .gitattributes file that enforces LF on files under bin/.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+bin/* eol=lf


### PR DESCRIPTION
In theory, once you were to reset your current clone, or make a new one, publishing to npm would send files with the correct line endings. Sorry I can't add an ssh user to my host, or else that would have simplified things a great deal...
