### PR TITLE
Treat files with custom extensions as JS

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -76,7 +76,7 @@ Module.prototype = {
     
     // Prototype FNs
     _parse : function() {
-        return this["_parse" + (this._type === "js" ? "Js" : "Css")]();
+        return this["_parse" + (this._type === "css" ? "Css" : "Js")]();
     },
 
     _parseJs : function() {

--- a/test/Configger.js
+++ b/test/Configger.js
@@ -19,13 +19,13 @@ describe("yui-configger", function() {
                     root : "./test/specimens/simple/"
                 });
             
-            assert.equal(c.options.root,            path.normalize("./test/specimens/simple/"));
-            assert.equal(c.options.dirs[0],         path.normalize("./test/specimens/simple/"));
-            assert.equal(c.options.tmpl,            "_config-template.js");
-            assert.equal(c.options.filter,          "/./");
-            assert.equal(c.options.prefix,          "");
-            assert.equal(c.options.cssprefix,       "css-");
-            assert.equal(c.options.loglevel,        "info");
+            assert.equal(c.options.root,      path.normalize("./test/specimens/simple/"));
+            assert.equal(c.options.dirs[0],   path.normalize("./test/specimens/simple/"));
+            assert.equal(c.options.tmpl,      "_config-template.js");
+            assert.equal(c.options.filter,    "/./");
+            assert.equal(c.options.prefix,    "");
+            assert.equal(c.options.cssprefix, "css-");
+            assert.equal(c.options.loglevel,  "info");
         });
         
         it("shouldn't load defaults when the CLI provided them", function() {
@@ -88,6 +88,16 @@ describe("yui-configger", function() {
         it("should find modules on the file system", function() {
             var c = new Configger({
                     root : "./test/specimens/simple/"
+                }),
+                modules = c._modules();
+            
+            assert(modules.length);
+        });
+
+        it("should find non-default modules on the file system", function() {
+           var c = new Configger({
+                    root       : "./test/specimens/mixed/",
+                    extensions : "js, css, mjs"
                 }),
                 modules = c._modules();
             
@@ -200,6 +210,19 @@ describe("yui-configger", function() {
             assert.equal(
                 c.run(),
                 _file("./test/specimens/mixed/js/_config-css.js")
+            );
+        });
+
+        it("should return a config string containing user-specified extensions from run (mixed)", function() {
+            var c = new Configger({
+                    root       : "./test/specimens/mixed",
+                    silent     : true,
+                    extensions : "mjs"
+                });
+            
+            assert.equal(
+                c.run(),
+                _file("./test/specimens/mixed/js/_config-mjs.js")
             );
         });
         

--- a/test/specimens/mixed/js/_config-mjs.js
+++ b/test/specimens/mixed/js/_config-mjs.js
@@ -1,0 +1,14 @@
+var test_config = {
+        groups: {
+            "/js/templates/": {
+                base: "/js/templates/",
+                modules: {
+                    "template-a": { path: "a.mjs" },
+                    "template-b": {
+                        path: "b.mjs",
+                        requires: ["template-a"]
+                    }
+                }
+            }
+        }
+    };

--- a/test/specimens/mixed/js/templates/a.mjs
+++ b/test/specimens/mixed/js/templates/a.mjs
@@ -1,0 +1,2 @@
+/*jshint yui:true */
+YUI.add("template-a", function() {});

--- a/test/specimens/mixed/js/templates/b.mjs
+++ b/test/specimens/mixed/js/templates/b.mjs
@@ -1,0 +1,10 @@
+/*global YUI:true */
+YUI.add("template-b", function(Y) {
+
+    //nothing, because it doesn't matter
+
+}, "@VERSION", {
+    requires : [
+        "template-a"
+    ]
+});


### PR DESCRIPTION
Fixes #27

Assume modules are JS unless they're explicitly named ".css". This is a
bit limiting in that you can't have other extensions for CSS modules,
but we already have to do custom work around CSS modules anyways so I'm
ok with that in this case.

Also beefs up test coverage some for custom extensions, though only JS files.
